### PR TITLE
Show quorum on results table

### DIFF
--- a/src/components/results/results-table.tsx
+++ b/src/components/results/results-table.tsx
@@ -23,8 +23,6 @@ interface ResultsTableProps {
 }
 
 function ReferendumResults({ referendum }: { referendum: ReferendumResult }) {
-	const totalVotes = referendum.yes + referendum.no;
-
 	return (
 		<div className="space-y-4">
 			<div className="grid grid-cols-2 gap-4">
@@ -105,10 +103,6 @@ function ReferendumResults({ referendum }: { referendum: ReferendumResult }) {
 					</p>
 				</div>
 			)}
-
-			<div className="text-center text-muted-foreground text-sm">
-				Total votes: {totalVotes}
-			</div>
 		</div>
 	);
 }
@@ -120,10 +114,6 @@ function CandidateResults({
 	candidates: CandidateResult[];
 	seatsAvailable?: number;
 }) {
-	const totalVotes = candidates.reduce(
-		(sum, c) => sum + (c.status === "ACTIVE" || !c.status ? c.votes : 0),
-		0,
-	);
 	const hasTies = candidates.some((c) => c.isTied);
 	const isMultiSeat = seatsAvailable > 1;
 	const useScore = isMultiSeat && candidates.some((c) => c.score !== undefined);
@@ -211,21 +201,16 @@ function CandidateResults({
 				</div>
 			)}
 
-			<div className="text-center text-muted-foreground text-sm">
-				{useScore ? (
-					<>
-						Total votes: {totalVotes} • {seatsAvailable}{" "}
-						{seatsAvailable === 1 ? "seat" : "seats"} available
-						<br />
-						<span className="text-xs">
-							Scores based on ranking position: 1st choice = {eligibleCount}{" "}
-							pts, 2nd = {eligibleCount - 1} pts, etc.
-						</span>
-					</>
-				) : (
-					`Total votes: ${totalVotes}`
-				)}
-			</div>
+			{useScore && (
+				<div className="text-center text-muted-foreground text-sm">
+					{seatsAvailable} {seatsAvailable === 1 ? "seat" : "seats"} available
+					<br />
+					<span className="text-xs">
+						Scores based on ranking position: 1st choice = {eligibleCount} pts,
+						2nd = {eligibleCount - 1} pts, etc.
+					</span>
+				</div>
+			)}
 		</div>
 	);
 }
@@ -237,10 +222,10 @@ export function ResultsTable({ ballot, isAdmin = false }: ResultsTableProps) {
 	return (
 		<Card>
 			<CardHeader>
-				<div className="flex items-start justify-between">
+				<div className="flex items-start justify-between gap-4">
 					<div>
 						<CardTitle>{ballot.ballotTitle}</CardTitle>
-						<div className="mt-1 flex gap-2">
+						<div className="mt-1 flex flex-wrap gap-2">
 							<Badge variant="outline">{ballot.ballotType}</Badge>
 							{ballot.college && (
 								<Badge variant="secondary">{ballot.college}</Badge>
@@ -253,17 +238,83 @@ export function ResultsTable({ ballot, isAdmin = false }: ResultsTableProps) {
 								<Badge variant="destructive">Quorum Not Met</Badge>
 							)}
 						</div>
-					</div>
-					<div className="text-right">
-						<div className="font-bold text-2xl">{ballot.totalVotes}</div>
-						<div className="text-muted-foreground text-sm">
-							total votes
-							{!ballot.hasReachedQuorum && (
-								<div className="text-xs">
-									(Quorum: {ballot.quorumThreshold})
+						{/* Quorum: turnout-based. Turnout + % turnout (always). Bar only for admin. */}
+						{ballot.eligibleVoters > 0 &&
+							typeof ballot.participatedCount === "number" && (
+								<div className="mt-2 space-y-1">
+									<div className="text-muted-foreground text-sm">
+										Turnout:{" "}
+										<span className="font-medium text-foreground tabular-nums">
+											{ballot.participatedCount} students voted
+										</span>{" "}
+										(
+										{ballot.eligibleVoters > 0
+											? `${(
+													(ballot.participatedCount / ballot.eligibleVoters) *
+														100
+												).toFixed(1)}% turnout`
+											: "—"}
+										){" · "}
+										Quorum: {ballot.quorumPercentage}% of eligible →{" "}
+										{ballot.quorumThreshold} required.
+									</div>
+									{/* Bar only for admin (same style as monitoring) */}
+									{isAdmin && (
+										<div className="space-y-1">
+											<div className="relative h-6 overflow-hidden rounded-md bg-muted">
+												<div
+													className={`h-full transition-all duration-300 ${
+														ballot.hasReachedQuorum
+															? "bg-green-600"
+															: "bg-primary"
+													}`}
+													style={{
+														width: `${Math.min(
+															(ballot.participatedCount /
+																ballot.eligibleVoters) *
+																100,
+															100,
+														)}%`,
+														minWidth:
+															ballot.participatedCount > 0 ? "4px" : "0",
+													}}
+												/>
+												<div
+													className="absolute top-0 h-full w-0.5 bg-destructive"
+													style={{
+														left: `${Math.min(
+															(ballot.quorumThreshold / ballot.eligibleVoters) *
+																100,
+															100,
+														)}%`,
+													}}
+													title={`Quorum: ${ballot.quorumThreshold} votes (${ballot.quorumPercentage}%)`}
+												/>
+											</div>
+											<div className="flex justify-between text-muted-foreground text-xs">
+												<span>{ballot.participatedCount} voted</span>
+												<span>
+													{ballot.quorumThreshold} required ·{" "}
+													{ballot.eligibleVoters} eligible
+												</span>
+											</div>
+										</div>
+									)}
 								</div>
 							)}
+						{ballot.eligibleVoters > 0 &&
+							typeof ballot.participatedCount !== "number" && (
+								<div className="mt-2 text-muted-foreground text-sm">
+									Quorum: {ballot.quorumPercentage}% of eligible →{" "}
+									{ballot.quorumThreshold} required.
+								</div>
+							)}
+					</div>
+					<div className="shrink-0 text-right">
+						<div className="font-bold font-mono text-2xl tabular-nums">
+							{ballot.totalCountedVotes ?? ballot.totalVotes}
 						</div>
+						<div className="text-muted-foreground text-sm">total votes</div>
 					</div>
 				</div>
 			</CardHeader>
@@ -277,13 +328,25 @@ export function ResultsTable({ ballot, isAdmin = false }: ResultsTableProps) {
 									Quorum Not Met
 								</h4>
 								<p className="text-blue-700 text-sm">
-									This ballot received {ballot.totalVotes} vote
-									{ballot.totalVotes !== 1 ? "s" : ""} but did not meet the
-									required quorum of {ballot.quorumThreshold} votes (
-									{ballot.eligibleVoters > 0
-										? `${ballot.quorumPercentage}% of ${ballot.eligibleVoters} eligible voters`
-										: "no eligible voters"}
-									).
+									{ballot.eligibleVoters > 0 ? (
+										<>
+											{typeof ballot.participatedCount === "number" ? (
+												<>
+													Turnout:{" "}
+													<span className="font-medium tabular-nums">
+														{ballot.participatedCount} students voted
+													</span>
+													{ballot.eligibleVoters > 0 &&
+														` (${((ballot.participatedCount / ballot.eligibleVoters) * 100).toFixed(1)}% turnout)`}
+													{" · "}
+												</>
+											) : null}
+											Quorum is {ballot.quorumPercentage}% of eligible (
+											{ballot.quorumThreshold} votes required).
+										</>
+									) : (
+										<>No eligible voters; quorum not applicable.</>
+									)}
 								</p>
 							</div>
 						</div>

--- a/src/components/results/results-table.tsx
+++ b/src/components/results/results-table.tsx
@@ -248,12 +248,9 @@ export function ResultsTable({ ballot, isAdmin = false }: ResultsTableProps) {
 											{ballot.participatedCount} students voted
 										</span>{" "}
 										(
-										{ballot.eligibleVoters > 0
-											? `${(
-													(ballot.participatedCount / ballot.eligibleVoters) *
-														100
-												).toFixed(1)}% turnout`
-											: "—"}
+										{`${(
+											(ballot.participatedCount / ballot.eligibleVoters) * 100
+										).toFixed(1)}% turnout`}
 										){" · "}
 										Quorum: {ballot.quorumPercentage}% of eligible →{" "}
 										{ballot.quorumThreshold} required.
@@ -336,8 +333,7 @@ export function ResultsTable({ ballot, isAdmin = false }: ResultsTableProps) {
 													<span className="font-medium tabular-nums">
 														{ballot.participatedCount} students voted
 													</span>
-													{ballot.eligibleVoters > 0 &&
-														` (${((ballot.participatedCount / ballot.eligibleVoters) * 100).toFixed(1)}% turnout)`}
+													{` (${((ballot.participatedCount / ballot.eligibleVoters) * 100).toFixed(1)}% turnout)`}
 													{" · "}
 												</>
 											) : null}

--- a/src/lib/results/calculator.ts
+++ b/src/lib/results/calculator.ts
@@ -64,8 +64,13 @@ export interface BallotResult {
 	ballotType: "EXECUTIVE" | "DIRECTOR" | "REFERENDUM";
 	college?: string | null;
 	seatsAvailable: number;
+	/** Total votes cast on this ballot (participation); used for display when same as counted */
 	totalVotes: number;
+	/** Votes counted toward the result (active candidates only, or YES+NO for referendum) */
+	totalCountedVotes: number;
 	eligibleVoters: number;
+	/** Eligible voters who participated in the election (or in this college for college ballots) */
+	participatedCount: number;
 	quorumThreshold: number;
 	hasReachedQuorum: boolean;
 	quorumPercentage: number;
@@ -107,7 +112,11 @@ export interface ElectionResults {
  */
 type PartialBallotResult = Omit<
 	BallotResult,
-	"eligibleVoters" | "quorumThreshold" | "hasReachedQuorum" | "quorumPercentage"
+	| "eligibleVoters"
+	| "participatedCount"
+	| "quorumThreshold"
+	| "hasReachedQuorum"
+	| "quorumPercentage"
 >;
 
 /**
@@ -169,6 +178,7 @@ export function calculateBallotResults(
 			college: ballot.college,
 			seatsAvailable: ballot.seatsAvailable,
 			totalVotes,
+			totalCountedVotes: effectiveVotes,
 			candidates: [candidateResult],
 		};
 	}
@@ -373,6 +383,10 @@ export function calculateBallotResults(
 		),
 	};
 
+	const totalCountedVotes = candidateResults
+		.filter((c) => c.status === "ACTIVE" || !c.status)
+		.reduce((sum, c) => sum + c.votes, 0);
+
 	return {
 		ballotId: ballot.id,
 		ballotTitle: ballot.title,
@@ -380,6 +394,7 @@ export function calculateBallotResults(
 		college: ballot.college,
 		seatsAvailable: ballot.seatsAvailable,
 		totalVotes,
+		totalCountedVotes,
 		candidates: candidateResults,
 		rankedChoiceDetails,
 	};
@@ -422,6 +437,8 @@ export function calculateReferendumResults(
 		isTied: yesVotes === noVotes && effectiveVotes > 0,
 	};
 
+	const totalCountedVotes = yesVotes + noVotes;
+
 	return {
 		ballotId: ballot.id,
 		ballotTitle: ballot.title,
@@ -429,6 +446,7 @@ export function calculateReferendumResults(
 		college: ballot.college,
 		seatsAvailable: ballot.seatsAvailable,
 		totalVotes,
+		totalCountedVotes,
 		referendum,
 	};
 }
@@ -482,8 +500,9 @@ export function calculateElectionResults(
 		const quorumThreshold = Math.ceil(
 			(eligibleForBallot * quorumPercentage) / 100,
 		);
-		const totalVotes = ballot.votes.length;
-		// Quorum = turnout (participated in election), not vote count on this ballot
+		// Quorum is based on turnout (eligible voters who participated), not votes on this ballot.
+		// Votes for withdrawn/disqualified candidates still count toward quorum (the voter participated).
+		// REFERENDUM: same as exec—overall (or college) turnout. Director: college turnout.
 		const participatedCount = ballot.college
 			? (collegeVotedCount?.get(
 					getCanonicalCollege(ballot.college) ?? ballot.college,
@@ -496,6 +515,7 @@ export function calculateElectionResults(
 			return {
 				...calculateReferendumResults(ballot),
 				eligibleVoters: eligibleForBallot,
+				participatedCount,
 				quorumThreshold,
 				hasReachedQuorum,
 				quorumPercentage,
@@ -504,6 +524,7 @@ export function calculateElectionResults(
 		return {
 			...calculateBallotResults(ballot),
 			eligibleVoters: eligibleForBallot,
+			participatedCount,
 			quorumThreshold,
 			hasReachedQuorum,
 			quorumPercentage,

--- a/src/lib/results/formatter.ts
+++ b/src/lib/results/formatter.ts
@@ -32,7 +32,9 @@ export function formatResultsAsCSV(results: ElectionResults): string {
 		if (ballot.college) {
 			lines.push(`# College: ${ballot.college}`);
 		}
-		lines.push(`# Total Votes: ${ballot.totalVotes}`);
+		lines.push(
+			`# Total Votes: ${ballot.totalCountedVotes ?? ballot.totalVotes}`,
+		);
 		lines.push("");
 
 		if (ballot.ballotType === "REFERENDUM" && ballot.referendum) {
@@ -235,7 +237,7 @@ export function createSummaryReport(results: ElectionResults): string {
 			`${ballot.ballotTitle} (${ballot.ballotType}${ballot.college ? ` - ${ballot.college}` : ""})`,
 		);
 		lines.push("=".repeat(60));
-		lines.push(`Total Votes: ${ballot.totalVotes}`);
+		lines.push(`Total Votes: ${ballot.totalCountedVotes ?? ballot.totalVotes}`);
 		lines.push("");
 
 		if (ballot.ballotType === "REFERENDUM" && ballot.referendum) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show quorum and turnout details in the ballot results table
> - Adds `participatedCount` and `totalCountedVotes` fields to ballot results in [calculator.ts](https://github.com/csaguelph/voting/pull/131/files#diff-e396131508d90527ae50004093cd36321442f10f03ab2dd478f12507f28ca6c0), distinguishing active-only vote counts from raw participation totals.
> - The results table header now shows turnout count, percentage, and quorum requirement; admins see a progress bar with a red quorum threshold marker.
> - The 'Quorum Not Met' notice now references `participatedCount` and `quorum` instead of `totalVotes`.
> - CSV and summary text reports prefer `totalCountedVotes` over `totalVotes` when available.
> - Behavioral Change: candidate and referendum results no longer display a 'Total votes' footer row; the total votes figure now uses counted votes (active candidates or YES+NO) rather than raw participation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d73549a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enhances the election results display by surfacing quorum and turnout information directly on each ballot's results card. It introduces two new computed fields on `BallotResult` — `totalCountedVotes` (votes for active candidates or YES/NO only) and `participatedCount` (eligible voters who participated) — and replaces the previous per-ballot "Total votes" footer with a richer header section showing turnout percentage, quorum threshold, and an admin-only progress bar.

- **`calculator.ts`**: Adds `totalCountedVotes` and `participatedCount` to `BallotResult` and `PartialBallotResult`, computed correctly across all ballot types (single-candidate, multi-candidate ranked choice, and referendum).
- **`results-table.tsx`**: Removes redundant `totalVotes` computation from sub-components. Adds turnout/quorum display in the card header with a visual progress bar (admin-only). Improves the quorum-not-met messaging with more detail.
- **`formatter.ts`**: Updates CSV export and summary report to prefer `totalCountedVotes` with a defensive `?? totalVotes` fallback for backward compatibility with cached results.
- Minor style nits: two redundant `ballot.eligibleVoters > 0` guards in the results table (dead else branches).

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds display-only UI improvements and well-computed derived fields with no changes to vote counting logic or data persistence.
- Score of 4 reflects clean backend logic additions (`totalCountedVotes`, `participatedCount`) that are consistent across all code paths, defensive fallbacks for cached data, and UI-only changes with no risk to core election integrity. Deducted 1 point for minor dead-code branches and a lack of tests for the new computed fields.
- No files require special attention. `src/components/results/results-table.tsx` has two minor redundant conditions that could be cleaned up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/results/results-table.tsx | Major UI update: replaces per-ballot total vote footers with a rich quorum/turnout section in the card header, including an admin-only progress bar. Has two minor redundant guard conditions but no functional bugs. |
| src/lib/results/calculator.ts | Adds `totalCountedVotes` and `participatedCount` fields to `BallotResult` interface and correctly computes them in all three code paths (single-candidate, multi-candidate, and referendum). |
| src/lib/results/formatter.ts | Updates CSV and summary report to display `totalCountedVotes` with a defensive `?? totalVotes` fallback for backward compatibility with cached data. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[calculateElectionResults] --> B{Ballot type?}
    B -->|REFERENDUM| C[calculateReferendumResults]
    B -->|EXECUTIVE/DIRECTOR| D[calculateBallotResults]
    C --> E[Compute totalCountedVotes\n= yesVotes + noVotes]
    D --> F{Single candidate?}
    F -->|Yes| G[totalCountedVotes = effectiveVotes\nyesVotes + noVotes]
    F -->|No| H[totalCountedVotes = sum of\nactive candidate votes]
    E --> I[Merge with quorum fields:\neligibleVoters, participatedCount,\nquorumThreshold, hasReachedQuorum]
    G --> I
    H --> I
    I --> J[BallotResult]
    J --> K[ResultsTable Component]
    J --> L[Formatter: CSV / Summary Report]
    K --> M{eligibleVoters > 0 &&\nparticipatedCount available?}
    M -->|Yes| N[Show turnout + quorum bar\nadmin-only progress bar]
    M -->|No| O[Show quorum threshold only]
    L --> P[Display totalCountedVotes ?? totalVotes]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/results/results-table.tsx
Line: 251-256

Comment:
**Redundant guard — else branch is unreachable**

The outer condition on line 242 already ensures `ballot.eligibleVoters > 0`, so this inner ternary's else branch (`"—"`) can never execute. Consider simplifying to just the template literal:

```suggestion
										{`${(
												(ballot.participatedCount / ballot.eligibleVoters) *
													100
											).toFixed(1)}% turnout`}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/results/results-table.tsx
Line: 339-340

Comment:
**Same redundant guard as above**

This `ballot.eligibleVoters > 0` check is inside the `ballot.eligibleVoters > 0` branch from line 331, so it's always `true` here. Can be simplified to just interpolate the turnout string directly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 407adeb</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->